### PR TITLE
An assertion for multi-line strings which throws a diff when it failes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ docs/_build/
 # PyBuilder
 target/
 
+# PyCharm working directory
+.idea
+
 *.dot
 *.png
 *.json

--- a/systest.py
+++ b/systest.py
@@ -313,9 +313,9 @@ class TestCase(object):
         if first != second:
             filename, line, _, _ = traceback.extract_stack()[-2]
             differ = difflib.Differ()
-            diff = differ.compare(first, second)
+            diff = differ.compare(first.splitlines(), second.splitlines())
 
-            text = ''.join(diff)
+            text = '\n'.join([line.rstrip('\n') for line in diff])
             raise TestCaseFailedError(
                 '{}:{}: Mismatch found:\n{}'.format(filename,
                                                     line,

--- a/systest.py
+++ b/systest.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import difflib
 import sys
 import os
 import threading
@@ -294,6 +295,31 @@ class TestCase(object):
                                                   line,
                                                   repr(first),
                                                   repr(second)))
+
+    def assert_multiline_equal(self, first, second):
+        """
+        Raises an exception if ``first`` and ``second`` are not equal.
+
+        This is equivalent to ``assert_equal`` except it requires the
+        arguments to be multi-line strings. The description of the failure is
+        presented in the exception as a diff. This is an easier way to
+        determine what has gone wrong in multi-line text.
+
+        :param first: Multi-line string
+        :param second: Multi-line string
+        :return: Nothing
+        :raises: TestCaseFailedError containing diff between strings.
+        """
+        if first != second:
+            filename, line, _, _ = traceback.extract_stack()[-2]
+            differ = difflib.Differ()
+            diff = differ.compare(first, second)
+
+            text = ''.join(diff)
+            raise TestCaseFailedError(
+                '{}:{}: Mismatch found:\n{}'.format(filename,
+                                                    line,
+                                                    text))
 
     def assert_true(self, condition):
         """Raise an exception if given condition `condition` is false.

--- a/systest.py
+++ b/systest.py
@@ -296,7 +296,7 @@ class TestCase(object):
                                                   repr(first),
                                                   repr(second)))
 
-    def assert_multiline_equal(self, first, second):
+    def assert_text_equal(self, first, second):
         """
         Raises an exception if ``first`` and ``second`` are not equal.
 

--- a/tests/test_systest.py
+++ b/tests/test_systest.py
@@ -13,6 +13,7 @@ from tests.testcases.fail import FailSetupTest
 from tests.testcases.fail import FailTearDownTest
 from tests.testcases.asserts import AssertsEqualTest
 from tests.testcases.asserts import AssertsNotEqualTest
+from tests.testcases.asserts import AssertsMultiLineEqual
 from tests.testcases.asserts import AssertsTrueTest
 from tests.testcases.asserts import AssertsFalseTest
 from tests.testcases.asserts import AssertsInTest
@@ -329,9 +330,31 @@ class SysTestTest(unittest.TestCase):
 
         sequencer = Sequencer("failed_asserts")
 
+        MULTI_ONE = '''First lines match
+Second line doesn't
+Third line pads    
+Fourth line fine
+'''
+        MULTI_TWO = '''First lines match
+Second line does not
+Third line pads
+Fourth line fine
+'''
+        MULTI_EXPECT = ''': Mismatch found:
+  First lines match
+- Second line doesn't
+?                  ^
++ Second line does not
+?                 + ^
+- Third line pads    
+?                ----
++ Third line pads
+  Fourth line fine'''
+
         result = sequencer.run(
             AssertsEqualTest(1, 2),
             AssertsNotEqualTest(2, 2),
+            AssertsMultiLineEqual(MULTI_ONE, MULTI_TWO),
             AssertsTrueTest(False),
             AssertsFalseTest(True),
             AssertsInTest(1, [0, 2]),
@@ -351,7 +374,7 @@ class SysTestTest(unittest.TestCase):
 
         sequencer.report()
 
-        self.assert_result(result, Result(0, 17, 0))
+        self.assert_result(result, Result(0, 18, 0))
 
         # Failure messages.
         with self.assertRaises(TestCaseFailedError) as cm:
@@ -363,6 +386,11 @@ class SysTestTest(unittest.TestCase):
             AssertsNotEqualTest(2, 2).run()
 
         self.assertTrue(str(cm.exception).endswith(': 2 is equal to 2'))
+
+        with self.assertRaises(TestCaseFailedError) as cm:
+            AssertsMultiLineEqual(MULTI_ONE, MULTI_TWO).run()
+
+        self.assertTrue(str(cm.exception).endswith(MULTI_EXPECT))
 
         with self.assertRaises(TestCaseFailedError) as cm:
             AssertsTrueTest(False).run()
@@ -446,9 +474,16 @@ class SysTestTest(unittest.TestCase):
 
         sequencer = Sequencer("passed_asserts")
 
+        MULTI_ONE = '''First lines match
+So does the second
+Even this line with trailing whitespace     
+Fourth line also fine
+'''
+
         result = sequencer.run(
             AssertsEqualTest(1, 1),
             AssertsNotEqualTest(2, 1),
+            AssertsMultiLineEqual(MULTI_ONE, MULTI_ONE),
             AssertsTrueTest(True),
             AssertsTrueTest(1),
             AssertsTrueTest([1]),
@@ -473,7 +508,7 @@ class SysTestTest(unittest.TestCase):
 
         sequencer.report()
 
-        self.assert_result(result, Result(22, 0, 0))
+        self.assert_result(result, Result(23, 0, 0))
 
 
     def test_testcase_description(self):

--- a/tests/test_systest.py
+++ b/tests/test_systest.py
@@ -13,7 +13,7 @@ from tests.testcases.fail import FailSetupTest
 from tests.testcases.fail import FailTearDownTest
 from tests.testcases.asserts import AssertsEqualTest
 from tests.testcases.asserts import AssertsNotEqualTest
-from tests.testcases.asserts import AssertsMultiLineEqual
+from tests.testcases.asserts import AssertsTextEqual
 from tests.testcases.asserts import AssertsTrueTest
 from tests.testcases.asserts import AssertsFalseTest
 from tests.testcases.asserts import AssertsInTest
@@ -330,17 +330,17 @@ class SysTestTest(unittest.TestCase):
 
         sequencer = Sequencer("failed_asserts")
 
-        MULTI_ONE = '''First lines match
+        TEXT_ONE = '''First lines match
 Second line doesn't
 Third line pads    
 Fourth line fine
 '''
-        MULTI_TWO = '''First lines match
+        TEXT_TWO = '''First lines match
 Second line does not
 Third line pads
 Fourth line fine
 '''
-        MULTI_EXPECT = ''': Mismatch found:
+        TEXT_EXPECT = ''': Mismatch found:
   First lines match
 - Second line doesn't
 ?                  ^
@@ -354,7 +354,7 @@ Fourth line fine
         result = sequencer.run(
             AssertsEqualTest(1, 2),
             AssertsNotEqualTest(2, 2),
-            AssertsMultiLineEqual(MULTI_ONE, MULTI_TWO),
+            AssertsTextEqual(TEXT_ONE, TEXT_TWO),
             AssertsTrueTest(False),
             AssertsFalseTest(True),
             AssertsInTest(1, [0, 2]),
@@ -388,9 +388,9 @@ Fourth line fine
         self.assertTrue(str(cm.exception).endswith(': 2 is equal to 2'))
 
         with self.assertRaises(TestCaseFailedError) as cm:
-            AssertsMultiLineEqual(MULTI_ONE, MULTI_TWO).run()
+            AssertsTextEqual(TEXT_ONE, TEXT_TWO).run()
 
-        self.assertTrue(str(cm.exception).endswith(MULTI_EXPECT))
+        self.assertTrue(str(cm.exception).endswith(TEXT_EXPECT))
 
         with self.assertRaises(TestCaseFailedError) as cm:
             AssertsTrueTest(False).run()
@@ -474,7 +474,7 @@ Fourth line fine
 
         sequencer = Sequencer("passed_asserts")
 
-        MULTI_ONE = '''First lines match
+        TEXT_ONE = '''First lines match
 So does the second
 Even this line with trailing whitespace     
 Fourth line also fine
@@ -483,7 +483,7 @@ Fourth line also fine
         result = sequencer.run(
             AssertsEqualTest(1, 1),
             AssertsNotEqualTest(2, 1),
-            AssertsMultiLineEqual(MULTI_ONE, MULTI_ONE),
+            AssertsTextEqual(TEXT_ONE, TEXT_ONE),
             AssertsTrueTest(True),
             AssertsTrueTest(1),
             AssertsTrueTest([1]),

--- a/tests/testcases/asserts.py
+++ b/tests/testcases/asserts.py
@@ -23,6 +23,17 @@ class AssertsNotEqualTest(TestCase):
         self.assert_not_equal(self.first, self.second)
 
 
+class AssertsMultiLineEqual(TestCase):
+
+    def __init__(self, first, second):
+        super(AssertsMultiLineEqual, self).__init__()
+        self.first = first
+        self.second = second
+
+    def run(self):
+        self.assert_multiline_equal(self.first, self.second)
+
+
 class AssertsTrueTest(TestCase):
 
     def __init__(self, condition):

--- a/tests/testcases/asserts.py
+++ b/tests/testcases/asserts.py
@@ -23,15 +23,15 @@ class AssertsNotEqualTest(TestCase):
         self.assert_not_equal(self.first, self.second)
 
 
-class AssertsMultiLineEqual(TestCase):
+class AssertsTextEqual(TestCase):
 
     def __init__(self, first, second):
-        super(AssertsMultiLineEqual, self).__init__()
+        super(AssertsTextEqual, self).__init__()
         self.first = first
         self.second = second
 
     def run(self):
-        self.assert_multiline_equal(self.first, self.second)
+        self.assert_text_equal(self.first, self.second)
 
 
 class AssertsTrueTest(TestCase):


### PR DESCRIPTION
System testing often needs to compare large blocks of multi-line text. The result of such a test failing a simple `assert_equal` is very hard to read. This change introduces an assertion specifically for such multi-line text blocks. When it fails it returns a diff allowing for easier comprehension of the problem.
